### PR TITLE
更丰富的Workflow

### DIFF
--- a/.github/workflows/gradle-dev.yml
+++ b/.github/workflows/gradle-dev.yml
@@ -1,0 +1,31 @@
+name: Develop CI
+
+on:
+  push:
+    branches-ignore: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build debug binary with Gradle
+        uses: gradle/gradle-command-action@v2
+        with:
+          arguments: assembleDebug
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: upload-apk
+          path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/gradle-dev.yml
+++ b/.github/workflows/gradle-dev.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: set up JDK 17
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -20,12 +20,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build debug binary with Gradle
+      - name: Build debug apk with Gradle
         uses: gradle/gradle-command-action@v2
         with:
           arguments: assembleDebug
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload debug apk to artifacts
+        uses: actions/upload-artifact@v3
         with:
-          name: upload-apk
+          name: app-debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -2,9 +2,8 @@ name: android master CI
 
 on:
   push:
-    branches: [ main ]
-    tags:
-      - '*'
+    branches: '*'
+    tags: '*'
   pull_request:
     branches: [ main ]
 
@@ -19,38 +18,57 @@ jobs:
           sed -i 's/\(versionCode\s*\)[0-9]\+/\1${{ github.run_number }}/' app/build.gradle
           sed -i 's/\(versionName\s*"\)[^"]*"/\1${{ github.ref_name }}"/' app/build.gradle
 
+      - name: Prepare signing key
+        run: |
+          echo '${{ secrets.SIGNING_KEY }}' | base64 -d > signingkey.jks
+
       - name: set up JDK 17
         uses: actions/setup-java@v2
         with:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Build debug binary with Gradle
-        if: startsWith(github.ref, 'refs/heads/main')
-        run: ./gradlew assembleDebug
-
+        uses: gradle/gradle-command-action@v2
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') && ! startsWith(github.head_ref, 'main/') }}
+        with:
+          arguments: :assembleDebug
+  
       - name: Build release binary with Gradle
-        if: startsWith(github.ref, 'refs/tags/')
-        run: ./gradlew assembleRelease
+        uses: gradle/gradle-command-action@v2
+        if: startsWith(github.ref, 'refs/tags/') && startsWith(github.head_ref, 'main/')
+        env:
+          ALIAS: ${{ secrets.ALIAS }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        with:
+          arguments: :assembleRelease
+
+      - name: Clean up CI files
+        run: rm signingkey.jks
 
       - name: Upload debug binary to artifacts
         uses: actions/upload-artifact@v2
-        if: startsWith(github.ref, 'refs/heads/main')
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') && ! startsWith(github.head_ref, 'main/') }}
         with:
           name: app-debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk
 
       - name: Upload release binary to artifacts
         uses: actions/upload-artifact@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && startsWith(github.head_ref, 'main/')
         with:
           name: app-release
           path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
 
-      - name: Release
+      - name: Setup release info
+        if: startsWith(github.ref, 'refs/tags/') && startsWith(github.head_ref, 'main/')
+        run: |
+          cd ${{github.workspace}}/app/build/outputs/apk/release
+          echo "OPT_APK_SHA=$(sha256sum *.apk | awk '{ print $1 }')" >> $GITHUB_ENV
+          echo "OPT_APK_NAME=$(ls *.apk)" >> $GITHUB_ENV
+
+      - name: Create & upload new release draft
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
@@ -58,3 +76,8 @@ jobs:
           tag_name: ${{ github.ref_name }}
           draft: true
           files: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
+          body: |            
+            ### 文件校验
+            | 文件 | SHA-256 |
+            | --- | --- |
+            | ${{ env.OPT_APK_NAME }} | ${{ env.OPT_APK_SHA }} |

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -19,6 +19,7 @@ jobs:
           sed -i 's/\(versionName\s*"\)[^"]*"/\1${{ github.ref_name }}"/' app/build.gradle
 
       - name: Prepare signing key
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: |
           echo '${{ secrets.SIGNING_KEY }}' | base64 -d > signingkey.jks
 
@@ -28,48 +29,52 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
       - name: Build debug binary with Gradle
         uses: gradle/gradle-command-action@v2
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') && ! startsWith(github.head_ref, 'main/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }} || github.ref != 'refs/heads/main'
         with:
-          arguments: :assembleDebug
+          arguments: assembleDebug
   
       - name: Build release binary with Gradle
         uses: gradle/gradle-command-action@v2
-        if: startsWith(github.ref, 'refs/tags/') && startsWith(github.head_ref, 'main/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         env:
           ALIAS: ${{ secrets.ALIAS }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         with:
-          arguments: :assembleRelease
+          arguments: assembleRelease
 
-      - name: Clean up CI files
+      - name: Clean up signing key
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: rm signingkey.jks
 
       - name: Upload debug binary to artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') && ! startsWith(github.head_ref, 'main/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }} || github.ref != 'refs/heads/main'
         with:
           name: app-debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk
 
       - name: Upload release binary to artifacts
         uses: actions/upload-artifact@v2
-        if: startsWith(github.ref, 'refs/tags/') && startsWith(github.head_ref, 'main/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         with:
           name: app-release
           path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
 
       - name: Setup release info
-        if: startsWith(github.ref, 'refs/tags/') && startsWith(github.head_ref, 'main/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: |
           cd ${{github.workspace}}/app/build/outputs/apk/release
           echo "OPT_APK_SHA=$(sha256sum *.apk | awk '{ print $1 }')" >> $GITHUB_ENV
           echo "OPT_APK_NAME=$(ls *.apk)" >> $GITHUB_ENV
 
       - name: Create & upload new release draft
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v1
         with:
           name: Doraemon

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -36,16 +36,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: ./gradlew assembleRelease
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload debug binary to artifacts
+        uses: actions/upload-artifact@v2
         if: startsWith(github.ref, 'refs/heads/main')
         with:
-          name: debug
+          name: app-debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload release binary to artifacts
+        uses: actions/upload-artifact@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: release
+          name: app-release
           path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
 
       - name: Release

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -3,16 +3,22 @@ name: android master CI
 on:
   push:
     branches: [ main ]
+    tags:
+      - '*'
   pull_request:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup version code
+        run: |
+          sed -i 's/\(versionCode\s*\)[0-9]\+/\1${{ github.run_number }}/' app/build.gradle
+          sed -i 's/\(versionName\s*"\)[^"]*"/\1${{ github.ref_name }}"/' app/build.gradle
+
       - name: set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -21,10 +27,32 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
+
+      - name: Build debug binary with Gradle
+        if: startsWith(github.ref, 'refs/heads/main')
         run: ./gradlew assembleDebug
 
+      - name: Build release binary with Gradle
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./gradlew assembleRelease
+
       - uses: actions/upload-artifact@v2
+        if: startsWith(github.ref, 'refs/heads/main')
         with:
-          name: upload-apk
+          name: debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk
+
+      - uses: actions/upload-artifact@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: release
+          path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Doraemon
+          tag_name: ${{ github.ref_name }}
+          draft: true
+          files: ${{github.workspace}}/app/build/outputs/apk/release/*.apk

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build debug binary with Gradle
         uses: gradle/gradle-command-action@v2
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }} || github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
         with:
           arguments: assembleDebug
   
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload debug binary to artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }} || github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
         with:
           name: app-debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build debug binary with Gradle
         uses: gradle/gradle-command-action@v2
-        if: github.ref == 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
+        if: github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
         with:
           arguments: assembleDebug
   
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload debug binary to artifacts
         uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
+        if: github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
         with:
           name: app-debug
           path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -9,14 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare signing key
-        run: |
-          echo '${{ secrets.SIGNING_KEY }}' | base64 -d > signingkey.jks
+        run: echo '${{ secrets.SIGNING_KEY }}' | base64 -d > signingkey.jks
 
-      - name: set up JDK 17
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -33,11 +32,13 @@ jobs:
         with:
           arguments: assembleRelease
 
-      - name: Clean up signing key
-        run: rm signingkey.jks
+      - name: Clean up
+        run: |
+          rm signingkey.jks
+          rm ${{github.workspace}}/app/build/outputs/apk/release/*-unsigned.apk
 
       - name: Upload release binary to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: app-release
           path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Clean up
         run: |
           rm signingkey.jks
-          rm ${{github.workspace}}/app/build/outputs/apk/release/*unsigned.apk
+          rm -f ${{github.workspace}}/app/build/outputs/apk/release/app-release-unsigned.apk
 
       - name: Upload release binary to artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Clean up
         run: |
           rm signingkey.jks
-          rm ${{github.workspace}}/app/build/outputs/apk/release/*-unsigned.apk
+          rm ${{github.workspace}}/app/build/outputs/apk/release/*unsigned.apk
 
       - name: Upload release binary to artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -1,11 +1,9 @@
-name: android master CI
+name: CI
 
 on:
   push:
-    branches: '*'
-    tags: '*'
-  pull_request:
     branches: [ main ]
+    tags: '*'
 
 jobs:
   build:
@@ -13,13 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup version code
-        run: |
-          sed -i 's/\(versionCode\s*\)[0-9]\+/\1${{ github.run_number }}/' app/build.gradle
-          sed -i 's/\(versionName\s*"\)[^"]*"/\1${{ github.ref_name }}"/' app/build.gradle
-
       - name: Prepare signing key
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: |
           echo '${{ secrets.SIGNING_KEY }}' | base64 -d > signingkey.jks
 
@@ -31,16 +23,9 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-
-      - name: Build debug binary with Gradle
-        uses: gradle/gradle-command-action@v2
-        if: github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
-        with:
-          arguments: assembleDebug
   
       - name: Build release binary with Gradle
         uses: gradle/gradle-command-action@v2
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         env:
           ALIAS: ${{ secrets.ALIAS }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
@@ -49,32 +34,21 @@ jobs:
           arguments: assembleRelease
 
       - name: Clean up signing key
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: rm signingkey.jks
-
-      - name: Upload debug binary to artifacts
-        uses: actions/upload-artifact@v2
-        if: github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/')
-        with:
-          name: app-debug
-          path: ${{github.workspace}}/app/build/outputs/apk/debug/*.apk
 
       - name: Upload release binary to artifacts
         uses: actions/upload-artifact@v2
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         with:
           name: app-release
           path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
 
       - name: Setup release info
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: |
           cd ${{github.workspace}}/app/build/outputs/apk/release
           echo "OPT_APK_SHA=$(sha256sum *.apk | awk '{ print $1 }')" >> $GITHUB_ENV
           echo "OPT_APK_NAME=$(ls *.apk)" >> $GITHUB_ENV
 
       - name: Create & upload new release draft
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v1
         with:
           name: Doraemon

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,15 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            storeFile rootProject.file("signingkey.jks")
+            storePassword System.getenv("KEY_STORE_PASSWORD")
+            keyAlias System.getenv("ALIAS")
+            keyPassword System.getenv("KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
### 运行
当分支为main时，将编译 debug apk
当分支为任意tag时，将编译 release apk。并将tag名称设为版本号。最后使用 softprops/action-gh-release@v1 推送到 Release 中

### 一些小问题
1. softprops/action-gh-release@v1 可能没有权限创建 Release。那就需要给build上可写入内容权限。现在要不要就不知道了。我之前要，但是刚刚试过是不用的
```yaml
jobs:
  build:
    permissions:
      contents: write
```
2. 签名
将Base64后的签名放在仓库 Settings -> Secrets and variables -> Actions -> Secrets 里面，然后 workflow 这样读取
```yaml
- name: Prepare signing key
  run: |
    echo '${{ secrets.SIGNING_KEY }}' | base64 -d > signingkey.jks

# 最后删掉掉
- name: Clean up signing key
  run: rm signingkey.jks
```
3. 建议将仓库里面的二进制文件清理一下，保持仓库整洁性